### PR TITLE
Release pidgeoneer v0.1.0

### DIFF
--- a/crates/pidgeoneer/CHANGELOG.md
+++ b/crates/pidgeoneer/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/security-union/pidgeon/releases/tag/pidgeoneer-v0.1.0) - 2025-03-09
+
+### Other
+
+- Fix release plz ([#2](https://github.com/security-union/pidgeon/pull/2))
+- Initial crates publish


### PR DESCRIPTION



## 🤖 New release

* `pidgeoneer`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/security-union/pidgeon/releases/tag/pidgeoneer-v0.1.0) - 2025-03-09

### Other

- Fix release plz ([#2](https://github.com/security-union/pidgeon/pull/2))
- Initial crates publish
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).