### PR TITLE
Release pidgeon v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pidgeon"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "iggy",

--- a/crates/pidgeon/CHANGELOG.md
+++ b/crates/pidgeon/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/security-union/pidgeon/compare/pidgeon-v0.1.1...pidgeon-v0.1.2) - 2025-03-09
+
+### Other
+
+- Adding drone example and bumping version ([#8](https://github.com/security-union/pidgeon/pull/8))
+- release-plz 4 ([#6](https://github.com/security-union/pidgeon/pull/6))

--- a/crates/pidgeon/Cargo.toml
+++ b/crates/pidgeon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidgeon"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "A robust, thread-safe PID controller library written in Rust"
 authors = ["Dario Alessandro"]


### PR DESCRIPTION



## 🤖 New release

* `pidgeon`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/security-union/pidgeon/compare/pidgeon-v0.1.1...pidgeon-v0.1.2) - 2025-03-09

### Other

- Adding drone example and bumping version ([#8](https://github.com/security-union/pidgeon/pull/8))
- release-plz 4 ([#6](https://github.com/security-union/pidgeon/pull/6))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).