### PR TITLE
Release pidgeon v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pidgeon"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "iggy",

--- a/crates/pidgeon/CHANGELOG.md
+++ b/crates/pidgeon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/security-union/pidgeon/compare/pidgeon-v0.2.0...pidgeon-v0.2.1) - 2025-03-15
+
+### Other
+
+- handle unwrap() properly using Result<T, PidError> ([#15](https://github.com/security-union/pidgeon/pull/15))
+
 ## [0.2.0](https://github.com/security-union/pidgeon/compare/pidgeon-v0.1.1...pidgeon-v0.2.0) - 2025-03-09
 
 ### Other

--- a/crates/pidgeon/Cargo.toml
+++ b/crates/pidgeon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidgeon"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A robust, thread-safe PID controller library written in Rust"
 authors = ["Dario Alessandro"]


### PR DESCRIPTION



## 🤖 New release

* `pidgeon`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/security-union/pidgeon/compare/pidgeon-v0.2.0...pidgeon-v0.2.1) - 2025-03-15

### Other

- handle unwrap() properly using Result<T, PidError> ([#15](https://github.com/security-union/pidgeon/pull/15))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).