### PR TITLE
Release pidgeon v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,7 +2713,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pidgeon"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "crossterm",

--- a/crates/pidgeon/CHANGELOG.md
+++ b/crates/pidgeon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/security-union/pidgeon/compare/pidgeon-v0.3.0...pidgeon-v0.3.1) - 2026-03-08
+
+### Other
+
+- Update video and enhance drone altitude simulation section
+
 ## [0.2.2](https://github.com/security-union/pidgeon/compare/pidgeon-v0.2.1...pidgeon-v0.2.2) - 2025-03-22
 
 ### Added

--- a/crates/pidgeon/Cargo.toml
+++ b/crates/pidgeon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pidgeon"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A robust, thread-safe PID controller library written in Rust"
 authors = ["Dario Alessandro"]


### PR DESCRIPTION



## 🤖 New release

* `pidgeon`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/security-union/pidgeon/compare/pidgeon-v0.3.0...pidgeon-v0.3.1) - 2026-03-08

### Other

- Update video and enhance drone altitude simulation section
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).